### PR TITLE
Deprecate testModifySite and introduce safer helpers

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for hspec-yesod
 
+## 0.2.1.0
+
+- The function `testModifySite` is deprecated and replaced with `testModifyMiddleware`, `testModifyFoundation`, and `testModifyFoundationAndMiddleware`.
+
 ## 0.2.0.1
 
 - Fixes unused import warnings in `Test.Hspec.Yesod.Internal`

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,7 +2,8 @@
 
 ## 0.2.1.0
 
-- The function `testModifySite` is deprecated and replaced with `testModifyMiddleware`, `testModifyFoundation`, and `testModifyFoundationAndMiddleware`.
+- [#6](https://github.com/parsonsmatt/hspec-yesod/pull/6)
+  - The function `testModifySite` is deprecated and replaced with `testModifyMiddleware`, `testModifyFoundation`, and `testModifyFoundationAndMiddleware`.
 
 ## 0.2.0.1
 

--- a/hspec-yesod.cabal
+++ b/hspec-yesod.cabal
@@ -1,5 +1,5 @@
 name:               hspec-yesod
-version:            0.2.0.1
+version:            0.2.1.0
 license:            MIT
 license-file:       LICENSE
 author:             Nubis <nubis@woobiz.com.ar>, Matt Parsons <parsonsmatt@gmail.com>


### PR DESCRIPTION
This PR deprecates `testModifySite` because it is confusing and surprising. Instead, `testModifyFoundation` can be used to modify the underlying site, and `testModifyMiddleware` can change the middleware, and `testModifyFoundationAndMiddleware` can be used for these.